### PR TITLE
Add optional --alias parameter to support domain aliases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,13 @@ Created:         2017-03-13 21:14:19
 ```
 
 #### site:make
-Create a new site on one of your servers.
+Create a new site on one of your servers. Use `--alias` to include one or more additional domains.
 
 ```bash
 $ forge site:make {serverId} 
     --domain=example.com
+    --alias=example.org
+    --alias=another-site.net
     --type=php
     --directory=/public
 ```

--- a/src/Commands/Sites/Make.php
+++ b/src/Commands/Sites/Make.php
@@ -18,6 +18,7 @@ class Make extends BaseCommand implements NeedsForge
         'domain' => 'domain',
         'type' => 'project_type',
         'directory' => 'directory',
+        'alias' => 'aliases',
     ];
 
     /**
@@ -30,6 +31,7 @@ class Make extends BaseCommand implements NeedsForge
             ->addOption('domain', null, InputOption::VALUE_REQUIRED, 'The domain of your new site.')
             ->addOption('type', null, InputOption::VALUE_REQUIRED, 'The type of application to install on the site. Can be either "php", "html", "Symfony", or "symfony_dev".', 'php')
             ->addOption('directory', null, InputOption::VALUE_REQUIRED, 'The base directory of the site.', '/public')
+            ->addOption('alias', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL, 'The aliases assigned to the site.')
             ->setDescription('Create a new site on one of your servers.');
     }
 

--- a/tests/Commands/SitesTest.php
+++ b/tests/Commands/SitesTest.php
@@ -84,6 +84,7 @@ class SitesTest extends TestCase
                 'domain' => 'example.com',
                 'project_type' => 'symfony_dev',
                 'directory' => '/public',
+                'aliases' => [],
             ], false);
 
         $this->command(Make::class)->execute([
@@ -95,6 +96,29 @@ class SitesTest extends TestCase
     }
 
     /** @test */
+    public function it_creates_a_site_with_aliases()
+    {
+        $this->forge->shouldReceive()
+            ->createSite('12345', [
+                'domain' => 'example.com',
+                'project_type' => 'symfony_dev',
+                'directory' => '/public',
+                'aliases' => [
+                    'foo.local',
+                    'bar.local',
+                ],
+            ], false);
+
+        $this->command(Make::class)->execute([
+            'server' => '12345',
+            '--domain' => 'example.com',
+            '--type' => 'symfony_dev',
+            '--directory' => '/public',
+            '--alias' => ['foo.local', 'bar.local'],
+        ]);
+    }
+
+    /** @test */
     public function it_defaults_to_php_site_when_not_supplying_the_option()
     {
         $this->forge->shouldReceive()
@@ -102,6 +126,7 @@ class SitesTest extends TestCase
                 'domain' => 'example.com',
                 'project_type' => 'php',
                 'directory' => '/public_html',
+                'aliases' => [],
             ], false);
 
         $this->command(Make::class)->execute([
@@ -119,6 +144,7 @@ class SitesTest extends TestCase
                 'domain' => 'example.com',
                 'project_type' => 'Symfony',
                 'directory' => '/public',
+                'aliases' => [],
             ], false);
 
         $this->command(Make::class)->execute([


### PR DESCRIPTION
This PR adds an alias command so that one can do the following:

forge site:make --domain=domain --alias=alias.one --alias=alias.two and it will register the aliases.