### PR TITLE
Add SSH config generation command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,23 @@ Delete an existing server. You will need to confirm your action.
 $ forge server:delete {serverId}
 ```
 
+#### server:ssh-config
+Generate an SSH config from your site list. `--with-sites` will also give you per-site SSH hosts and will use correct
+usernames for isolated sites.
+
+```bash
+$ forge server:ssh-config
+
+Host loopy-aardvark
+    Hostname 111.222.111.222
+    Port 22
+    User forge
+
+Host daring-squirrel
+    Hostname 111.222.111.223
+    Port 22
+```
+
 ---
 
 ### Sites

--- a/bin/forge
+++ b/bin/forge
@@ -21,6 +21,7 @@ $app->addCommands([
     new Servers\Make,
     new Servers\ListAll,
     new Servers\Show,
+    new Servers\SshConfig,
     new Servers\Update,
     new Servers\Delete,
     new Servers\Reboot,

--- a/src/Commands/Servers/SshConfig.php
+++ b/src/Commands/Servers/SshConfig.php
@@ -4,10 +4,9 @@ namespace Sven\ForgeCLI\Commands\Servers;
 
 use Sven\ForgeCLI\Commands\BaseCommand;
 use Sven\ForgeCLI\Contracts\NeedsForge;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Themsaid\Forge\Resources\Server;
 
 class SshConfig extends BaseCommand implements NeedsForge
 {
@@ -44,7 +43,8 @@ class SshConfig extends BaseCommand implements NeedsForge
         return 0;
     }
 
-    public function sshTemplate($name, $ip, $port = 22, $username = 'forge', $directory = null) {
+    public function sshTemplate($name, $ip, $port = 22, $username = 'forge', $directory = null)
+    {
         $template = "Host {$name}\n";
         $template .= "    Hostname {$ip}\n";
         $template .= "    Port {$port}\n";
@@ -54,6 +54,7 @@ class SshConfig extends BaseCommand implements NeedsForge
             $template .= "    RemoteCommand cd {$directory}; exec \$SHELL;\n";
         }
         $template .= "\n";
+
         return $template;
     }
 }

--- a/src/Commands/Servers/SshConfig.php
+++ b/src/Commands/Servers/SshConfig.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Sven\ForgeCLI\Commands\Servers;
+
+use Sven\ForgeCLI\Commands\BaseCommand;
+use Sven\ForgeCLI\Contracts\NeedsForge;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Themsaid\Forge\Resources\Server;
+
+class SshConfig extends BaseCommand implements NeedsForge
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configure()
+    {
+        $this->setName('server:ssh-config')
+            ->addOption('with-sites', null, InputOption::VALUE_NONE, 'Adds specific sites, too. Useful if you are using isolation.')
+            ->setDescription('Generate an SSH configuration file for servers.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $servers = $this->forge->servers();
+
+        foreach ($servers as $server) {
+            $output->write($this->sshTemplate($server->name, $server->ipAddress, $server->sshPort));
+
+            if ($input->getOption('with-sites')) {
+                $sites = $this->forge->sites($server->id);
+
+                foreach ($sites as $site) {
+                    $output->write($this->sshTemplate("{$server->name}:{$site->name}", $server->ipAddress, $server->sshPort, $site->username ?? 'forge', $site->name));
+                }
+                $output->writeln('');
+            }
+        }
+
+        return 0;
+    }
+
+    public function sshTemplate($name, $ip, $port = 22, $username = 'forge', $directory = null) {
+        $template = "Host {$name}\n";
+        $template .= "    Hostname {$ip}\n";
+        $template .= "    Port {$port}\n";
+        $template .= "    User {$username}\n";
+        if ($directory) {
+            $template .= "    RequestTTY yes\n";
+            $template .= "    RemoteCommand cd {$directory}; exec \$SHELL;\n";
+        }
+        $template .= "\n";
+        return $template;
+    }
+}

--- a/src/Commands/Servers/SshConfig.php
+++ b/src/Commands/Servers/SshConfig.php
@@ -47,14 +47,14 @@ class SshConfig extends BaseCommand implements NeedsForge
 
     public function outputTemplate($name, $ip, $port = 22, $username = 'forge', $directory = null)
     {
-        return [
+        return array_merge([
             "Host {$name}",
             "    Hostname {$ip}",
             "    Port {$port}",
             "    User {$username}",
-        ] + ($directory ? [
+        ], ($directory ? [
             '    RequestTTY yes',
             "    RemoteCommand cd {$directory}; exec \$SHELL;",
-        ] : []);
+        ] : []));
     }
 }

--- a/src/Commands/Servers/SshConfig.php
+++ b/src/Commands/Servers/SshConfig.php
@@ -28,33 +28,33 @@ class SshConfig extends BaseCommand implements NeedsForge
         $servers = $this->forge->servers();
 
         foreach ($servers as $server) {
-            $output->write($this->sshTemplate($server->name, $server->ipAddress, $server->sshPort));
+            $output->writeln($this->outputTemplate($server->name, $server->ipAddress, $server->sshPort));
+            $output->writeln('');
 
             if ($input->getOption('with-sites')) {
                 $sites = $this->forge->sites($server->id);
 
                 foreach ($sites as $site) {
-                    $output->write($this->sshTemplate("{$server->name}:{$site->name}", $server->ipAddress, $server->sshPort, $site->username ?? 'forge', $site->name));
+                    $output->writeln($this->outputTemplate("{$server->name}:{$site->name}", $server->ipAddress, $server->sshPort,
+                        $site->username ?? 'forge', $site->name));
+                    $output->writeln('');
                 }
-                $output->writeln('');
             }
         }
 
         return 0;
     }
 
-    public function sshTemplate($name, $ip, $port = 22, $username = 'forge', $directory = null)
+    public function outputTemplate($name, $ip, $port = 22, $username = 'forge', $directory = null)
     {
-        $template = "Host {$name}\n";
-        $template .= "    Hostname {$ip}\n";
-        $template .= "    Port {$port}\n";
-        $template .= "    User {$username}\n";
-        if ($directory) {
-            $template .= "    RequestTTY yes\n";
-            $template .= "    RemoteCommand cd {$directory}; exec \$SHELL;\n";
-        }
-        $template .= "\n";
-
-        return $template;
+        return [
+            "Host {$name}",
+            "    Hostname {$ip}",
+            "    Port {$port}",
+            "    User {$username}",
+        ] + ($directory ? [
+            "    RequestTTY yes",
+            "    RemoteCommand cd {$directory}; exec \$SHELL;",
+        ] : []);
     }
 }

--- a/src/Commands/Servers/SshConfig.php
+++ b/src/Commands/Servers/SshConfig.php
@@ -53,7 +53,7 @@ class SshConfig extends BaseCommand implements NeedsForge
             "    Port {$port}",
             "    User {$username}",
         ] + ($directory ? [
-            "    RequestTTY yes",
+            '    RequestTTY yes',
             "    RemoteCommand cd {$directory}; exec \$SHELL;",
         ] : []);
     }

--- a/tests/Commands/ServersTest.php
+++ b/tests/Commands/ServersTest.php
@@ -2,16 +2,16 @@
 
 namespace Sven\ForgeCLI\Tests\Commands;
 
-use Themsaid\Forge\Resources\Site;
 use Sven\ForgeCLI\Commands\Servers\Delete;
 use Sven\ForgeCLI\Commands\Servers\ListAll;
 use Sven\ForgeCLI\Commands\Servers\Make;
 use Sven\ForgeCLI\Commands\Servers\Reboot;
 use Sven\ForgeCLI\Commands\Servers\Show;
+use Sven\ForgeCLI\Commands\Servers\SshConfig;
 use Sven\ForgeCLI\Commands\Servers\Update;
 use Sven\ForgeCLI\Tests\TestCase;
 use Themsaid\Forge\Resources\Server;
-use Sven\ForgeCLI\Commands\Servers\SshConfig;
+use Themsaid\Forge\Resources\Site;
 
 class ServersTest extends TestCase
 {
@@ -181,7 +181,6 @@ class ServersTest extends TestCase
             ->andReturn([
                 new Site(['id' => '1234', 'name' => 'site-test', 'server_id' => '1234', 'username' => 'notforge']),
             ]);
-
 
         $tester = $this->command(SshConfig::class);
 


### PR DESCRIPTION
This patch adds the ability to create an SSH config from the sites/servers.

Usage:

```bash
forge servers:ssh-config # Generate default ssh connections for all servers.
forge servers:ssh-config --with-sites # Generate per-site ssh hosts {server}:{sitename}
```
