### PR TITLE
Add `MysqlUsers` commands to bin/forge

### DIFF
--- a/bin/forge
+++ b/bin/forge
@@ -2,7 +2,7 @@
 <?php
 
 use Sven\ForgeCLI\Commands\{
-    Authorize, Certificates, Credentials, Daemons, Databases, Deployment,
+    Authorize, Certificates, Credentials, Daemons, Databases, MysqlUsers, Deployment,
     DeployScript, Env, FirewallRules, Jobs, NginxConfig, Projects, QuickDeploy,
     Recipes, Servers, Services, SshKeys, Sites, Workers
 };
@@ -57,6 +57,10 @@ $app->addCommands([
     new Databases\Make,
     new Databases\Delete,
     new Databases\Show,
+    new MysqlUsers\ListAll,
+    new MysqlUsers\Make,
+    new MysqlUsers\Delete,
+    new MysqlUsers\Show,
     new Workers\ListAll,
     new Workers\Make,
     new Workers\Delete,


### PR DESCRIPTION
I saw the commit resolving #48, however the commands were not loaded in `bin/forge`.

I did not test, however the provided changes helped me to enable those commands.